### PR TITLE
Fix bad URL problem

### DIFF
--- a/src/java/fr/paris/lutece/plugins/participatoryideation/web/IdeationApp.java
+++ b/src/java/fr/paris/lutece/plugins/participatoryideation/web/IdeationApp.java
@@ -271,7 +271,7 @@ public class IdeationApp extends MVCApplication
         // If user's personal infos not filled, then redirect to the 'complete myinfos' webpage
         if ( !checkUserAuthorized( request ) )
         {
-            return redirect( request, MyInfosService.getInstance( ).getUrlMyInfosFillAction( ) );
+            return redirect( request, AppPathService.getProdUrl( request ) + MyInfosService.getInstance( ).getUrlMyInfosFillAction( ) );
         }
 
         // Some automatic stuff


### PR DESCRIPTION
If the profile is not fully filled yet (example: not fill birthday field) and I will visit ideation page `jsp/site/Portal.jsp?page=ideation&campaign=A`, return bad URL. This commit resolve this.

Correction based on this:
https://github.com/lutece-secteur-public/particip-plugin-participatoryideation/blob/ce6c829a22b437765be0a93561d2b18e414e5a43/src/java/fr/paris/lutece/plugins/participatoryideation/web/ProposalXPage.java#L177